### PR TITLE
set up STDOUT logger before running transport specs

### DIFF
--- a/spec/transport_spec.rb
+++ b/spec/transport_spec.rb
@@ -5,6 +5,10 @@ require "logger"
 describe "Sensu::Transport" do
   include Helpers
 
+  before do
+    Sensu::Transport.logger = Logger.new(STDOUT)
+  end
+
   it "can load and connect to the rabbitmq transport" do
     async_wrapper do
       options = {}


### PR DESCRIPTION
I believe this will fix the broken specs for changes in sensu/sensu-transport#34
